### PR TITLE
Implement basic retrieve functionality

### DIFF
--- a/decayrag/decayrag/__init__.py
+++ b/decayrag/decayrag/__init__.py
@@ -9,6 +9,7 @@ from .ingest import (
     upsert_embeddings,
     batch_ingest,
 )
+from .retrieval import retrieve
 
 __all__ = [
     "parse_document",
@@ -16,5 +17,6 @@ __all__ = [
     "embed_chunks",
     "upsert_embeddings",
     "batch_ingest",
+    "retrieve",
 ]
 

--- a/decayrag/decayrag/retrieval.py
+++ b/decayrag/decayrag/retrieval.py
@@ -1,0 +1,117 @@
+"""Query-time retrieval utilities for DecayRAG."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import List
+
+import faiss
+import numpy as np
+
+from .pooling import apply_neighbor_decay_scores
+
+__all__ = [
+    "embed_query",
+    "compute_chunk_similarities",
+    "blend_scores",
+    "top_k_chunks",
+    "retrieve",
+]
+
+
+def embed_query(query: str, model_name: str) -> np.ndarray:
+    """Embed a query string using the chosen model or a fallback."""
+    texts = [query]
+    try:
+        from .ingest import _api_embed  # type: ignore
+
+        embeds = _api_embed(texts, model_name)
+    except Exception:
+        try:
+            from sentence_transformers import SentenceTransformer
+
+            st_model = SentenceTransformer(model_name)
+            embeds = st_model.encode(texts, convert_to_numpy=True, normalize_embeddings=False)
+        except Exception:
+            rng = np.random.default_rng(0)
+            embeds = rng.standard_normal((1, 384)).astype(np.float32)
+
+    norms = np.linalg.norm(embeds, axis=1, keepdims=True)
+    np.divide(embeds, norms, out=embeds, where=norms != 0)
+    return embeds[0]
+
+
+def compute_chunk_similarities(query_vec: np.ndarray, chunk_embeds: np.ndarray) -> np.ndarray:
+    """Return the dot-product similarity between query_vec and each chunk embedding."""
+    if query_vec.ndim != 1:
+        query_vec = query_vec.reshape(-1)
+    return (chunk_embeds @ query_vec).astype(np.float32)
+
+
+def blend_scores(raw: np.ndarray, decayed: np.ndarray, *, alpha: float = 0.5, beta: float = 0.5) -> np.ndarray:
+    """Blend raw and neighbour-decayed scores."""
+    if raw.shape != decayed.shape:
+        raise ValueError("Score arrays must have the same shape")
+    return (alpha * raw + beta * decayed).astype(np.float32)
+
+
+def top_k_chunks(scores: np.ndarray, k: int) -> np.ndarray:
+    """Return indices of the top-k scores in descending order."""
+    if k <= 0 or len(scores) == 0:
+        return np.array([], dtype=int)
+    k = min(k, len(scores))
+    idx = np.argpartition(-scores, k - 1)[:k]
+    idx = idx[np.argsort(-scores[idx])]
+    return idx.astype(int)
+
+
+def _load_index(index_path: str) -> faiss.Index:
+    return faiss.read_index(str(Path(index_path)))
+
+
+def _load_metadata(meta_path: str) -> List[dict]:
+    with open(meta_path, "r", encoding="utf-8") as fh:
+        return [json.loads(line) for line in fh if line.strip()]
+
+
+def retrieve(
+    query: str,
+    index_path: str,
+    *,
+    model: str = "text-embedding-3-small",
+    top_k: int = 5,
+    decay: bool = True,
+    blend: bool = True,
+) -> List[dict]:
+    """Search *index_path* for chunks relevant to *query*."""
+    index = _load_index(index_path)
+    meta = _load_metadata(index_path + ".meta")
+    if index.ntotal != len(meta):
+        raise ValueError("Metadata size does not match index")
+
+    # reconstruct embeddings from the underlying flat index
+    if hasattr(index, "index") and hasattr(index.index, "reconstruct_n"):
+        embeds = index.index.reconstruct_n(0, index.ntotal)
+    elif hasattr(index, "reconstruct_n"):
+        embeds = index.reconstruct_n(0, index.ntotal)
+    else:
+        raise ValueError("Index type does not support reconstruct")
+
+    qvec = embed_query(query, model)
+    raw_scores = compute_chunk_similarities(qvec, embeds)
+
+    final_scores = raw_scores
+    if decay:
+        decayed = apply_neighbor_decay_scores(raw_scores)
+        final_scores = decayed
+        if blend:
+            final_scores = blend_scores(raw_scores, decayed)
+
+    top_idx = top_k_chunks(final_scores, top_k)
+    results = []
+    for i in top_idx:
+        item = dict(meta[i])
+        item["score"] = float(final_scores[i])
+        results.append(item)
+    return results

--- a/tests/test_retrieval.py
+++ b/tests/test_retrieval.py
@@ -1,0 +1,32 @@
+import numpy as np
+from pathlib import Path
+import sys
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from decayrag import upsert_embeddings, retrieve
+import decayrag.decayrag.retrieval as r
+
+
+def test_retrieve_basic(tmp_path, monkeypatch):
+    index = tmp_path / "index.faiss"
+    chunks = [
+        {"doc_id": "doc1", "chunk_id": 0, "text": "apple", "level": [], "position": 0},
+        {"doc_id": "doc2", "chunk_id": 0, "text": "banana", "level": [], "position": 0},
+    ]
+    embeds = np.array([[1.0, 0.0, 0.0], [0.0, 1.0, 0.0]], dtype=np.float32)
+    upsert_embeddings(str(index), chunks, embeds)
+
+    def fake_embed_query(query: str, model_name: str = "") -> np.ndarray:
+        if "apple" in query.lower():
+            return np.array([1.0, 0.0, 0.0], dtype=np.float32)
+        return np.array([0.0, 1.0, 0.0], dtype=np.float32)
+
+    monkeypatch.setattr(r, "embed_query", fake_embed_query)
+
+    results = retrieve("apple", str(index), top_k=1, decay=False, blend=False)
+    assert len(results) == 1
+    assert results[0]["doc_id"] == "doc1"
+
+    results = retrieve("banana", str(index), top_k=1, decay=False, blend=False)
+    assert len(results) == 1
+    assert results[0]["doc_id"] == "doc2"


### PR DESCRIPTION
## Summary
- add `retrieve` and helper functions in retrieval module
- expose `retrieve` in package `__init__`
- test retrieval workflow with a simple FAISS index

## Testing
- `pytest -q`