### PR TITLE
Implement top_k_chunks retrieval helper

### DIFF
--- a/decayrag/decayrag/retrieval.py
+++ b/decayrag/decayrag/retrieval.py
@@ -1,0 +1,34 @@
+"""Query-time retrieval helpers for DecayRAG."""
+
+from __future__ import annotations
+
+import numpy as np
+
+__all__ = ["top_k_chunks"]
+
+
+def top_k_chunks(scores: np.ndarray, k: int) -> np.ndarray:
+    """Return indices of the ``k`` highest *scores* in descending order.
+
+    Parameters
+    ----------
+    scores : np.ndarray
+        1-D array of similarity scores.
+    k : int
+        Number of top entries to return.
+
+    Returns
+    -------
+    np.ndarray
+        Indices of the top ``k`` scores sorted from highest to lowest.
+    """
+    if scores.ndim != 1:
+        raise ValueError("scores must be 1-D")
+    if k <= 0:
+        return np.array([], dtype=int)
+
+    k = min(k, len(scores))
+    # argsort on the negated scores gives descending order. Using a stable sort
+    # ensures that ties are resolved by the original index order.
+    sorted_idx = np.argsort(-scores, kind="stable")
+    return sorted_idx[:k]

--- a/tests/test_retrieval.py
+++ b/tests/test_retrieval.py
@@ -1,0 +1,26 @@
+import sys
+from pathlib import Path
+
+import numpy as np
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from decayrag.decayrag.retrieval import top_k_chunks
+
+
+def test_top_k_basic() -> None:
+    scores = np.array([0.1, 0.5, 0.3, 0.9], dtype=np.float32)
+    idx = top_k_chunks(scores, 2)
+    assert list(idx) == [3, 1]
+
+
+def test_top_k_ties() -> None:
+    scores = np.array([0.8, 0.8, 0.5], dtype=np.float32)
+    idx = top_k_chunks(scores, 2)
+    assert list(idx) == [0, 1]
+
+
+def test_top_k_overflow() -> None:
+    scores = np.array([0.2, 0.1], dtype=np.float32)
+    idx = top_k_chunks(scores, 5)
+    assert list(idx) == [0, 1]


### PR DESCRIPTION
## Summary
- implement `top_k_chunks` to sort scores in descending order using a stable argsort
- add unit tests covering ranking with and without ties

## Testing
- `pytest -q`