### PR TITLE
Switch embeddings to OpenAI API

### DIFF
--- a/decayrag/decayrag/ingest.py
+++ b/decayrag/decayrag/ingest.py
@@ -138,20 +138,9 @@ def _api_embed(texts: List[str], model_name: str) -> np.ndarray:
 
 
 def embed_chunks(chunks: List[dict], model_name: str) -> np.ndarray:
-    """Embed chunk texts with a chosen model or sentence-transformer fallback."""
+    """Embed chunk texts using the OpenAI embeddings API."""
     texts = [c["text"] for c in chunks]
-    try:
-        embeds = _api_embed(texts, model_name)
-    except Exception:
-        try:
-            from sentence_transformers import SentenceTransformer
-
-            st_model = SentenceTransformer(model_name)
-            embeds = st_model.encode(texts, convert_to_numpy=True, normalize_embeddings=False)
-        except Exception:
-            rng = np.random.default_rng(0)
-            embeds = rng.standard_normal((len(texts), 384)).astype(np.float32)
-
+    embeds = _api_embed(texts, model_name)
     norms = np.linalg.norm(embeds, axis=1, keepdims=True)
     np.divide(embeds, norms, out=embeds, where=norms != 0)
     return embeds

--- a/decayrag/decayrag/retrieval.py
+++ b/decayrag/decayrag/retrieval.py
@@ -15,6 +15,7 @@ from .pooling import (
     compute_global_embedding,
     blend_embeddings,
 )
+from . import ingest
 
 __all__ = [
     "embed_query",
@@ -26,25 +27,13 @@ __all__ = [
 
 
 def embed_query(query: str, model_name: str) -> np.ndarray:
-    """Embed a query string using the chosen model or a fallback."""
-    texts = [query]
-    try:
-        from .ingest import _api_embed  # type: ignore
-
-        embeds = _api_embed(texts, model_name)
-    except Exception:
-        try:
-            from sentence_transformers import SentenceTransformer
-
-            st_model = SentenceTransformer(model_name)
-            embeds = st_model.encode(texts, convert_to_numpy=True, normalize_embeddings=False)
-        except Exception:
-            rng = np.random.default_rng(0)
-            embeds = rng.standard_normal((1, 384)).astype(np.float32)
-
-    norms = np.linalg.norm(embeds, axis=1, keepdims=True)
-    np.divide(embeds, norms, out=embeds, where=norms != 0)
-    return embeds[0]
+    """Embed a query string using the OpenAI embeddings API."""
+    embeds = ingest._api_embed([query], model_name)
+    vec = embeds[0]
+    norm = np.linalg.norm(vec)
+    if norm != 0:
+        vec = vec / norm
+    return vec
 
 
 def compute_chunk_similarities(query_vec: np.ndarray, chunk_embeds: np.ndarray) -> np.ndarray:


### PR DESCRIPTION
## Summary
- Use OpenAI embeddings for chunk ingestion and query encoding
- Adjust tests to mock OpenAI embedding calls

## Testing
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a79c7205608330ba16cd7fbc84a709